### PR TITLE
Fixed "insert path" required a "filepath" and not a "path" & fixed *NIX path stuff.

### DIFF
--- a/src/commands/WebpackController.php
+++ b/src/commands/WebpackController.php
@@ -259,18 +259,29 @@ class WebpackController extends Controller
                         $error = 'The composer.json file must exist!';
                         return false;
                     }
+
+                    if (is_dir(!$input)) {
+                        $error = 'Directory "'.$input.'" does not exist!';
+                        return false;
+                    }
+                    if (is_file($input)) {
+                        $error = 'Please insert a path: e.g. "app/"';
+                        return false;
+                    }
                     return true;
                 }
             ];
             if (file_exists('composer.json') === true) {
                 $options['default'] = 'composer.json';
             }
+
             $composerJson = $this->prompt('Relative path to composer.json ?', $options);
-            $composerPath = pathinfo($composerJson, PATHINFO_DIRNAME);
+            $composerPath = realpath($composerJson);
+
             $this->composerJsonPath = $composerPath;
         }
-        return $this->composerJsonPath;
 
+        return $this->composerJsonPath;
     }
 
     /**
@@ -281,7 +292,7 @@ class WebpackController extends Controller
     {
         $this->stdout('Generating package.json'."\n", Console::FG_GREEN, Console::BOLD);
         $composerJsonPath = $this->findComposerJson();
-        $composerData = Json::decode(file_get_contents($composerJsonPath.'/composer.json'));
+        $composerData = Json::decode(file_get_contents($composerJsonPath.DIRECTORY_SEPARATOR.'composer.json'));
 
         $packageJson = Json::decode(file_get_contents(Yii::getAlias($this->packageJson)));
 


### PR DESCRIPTION
- Fixed: Entering a "path" in "Relative path to composer.json ?" input question resulted in a PHP-Error.


```
PHP Warning 'yii\base\ErrorException' with message 'file_get_contents(./composer.json): failed to open stream: No such file or directory'

in C:\development\webroot\relaunch2017-web\app\vendor\sweelix\yii2-webpack\src\commands\WebpackController.php:297

Stack trace:
#0 C:\development\webroot\relaunch2017-web\app\vendor\sweelix\yii2-webpack\src\commands\WebpackController.php(75): sweelix\webpack\commands\WebpackController->generatePackageJson()
#1 C:\development\webroot\relaunch2017-web\app\vendor\yiisoft\yii2\base\InlineAction.php(57): sweelix\webpack\commands\WebpackController->actionInit()
#2 C:\development\webroot\relaunch2017-web\app\vendor\yiisoft\yii2\base\InlineAction.php(57): ::call_user_func_array:{C:\development\webroot\relaunch2017-web\app\vendor\yiisoft\yii2\base\InlineAction.php:57}()
#3 C:\development\webroot\relaunch2017-web\app\vendor\yiisoft\yii2\base\Controller.php(156): yii\base\InlineAction->runWithParams()
#4 C:\development\webroot\relaunch2017-web\app\vendor\yiisoft\yii2\console\Controller.php(128): yii\base\Controller->runAction()
#5 C:\development\webroot\relaunch2017-web\app\vendor\yiisoft\yii2\base\Module.php(523): yii\console\Controller->runAction()
#6 C:\development\webroot\relaunch2017-web\app\vendor\yiisoft\yii2\console\Application.php(180): yii\base\Module->runAction()
#7 C:\development\webroot\relaunch2017-web\app\vendor\yiisoft\yii2\console\Application.php(147): yii\console\Application->runAction()
#8 C:\development\webroot\relaunch2017-web\app\vendor\yiisoft\yii2\base\Application.php(380): yii\console\Application->handleRequest()
#9 C:\development\webroot\relaunch2017-web\app\yii(20): yii\base\Application->run()
#10 {main}
```

- Fixed:  *NIX path stuff for Windows enviromnent.